### PR TITLE
chore(deploy): Add demo:deploy script to deploy demo to gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "demo": "webpack-dev-server --config demo/webpack.config.js --debug --content-base demo --inline --hot --colors",
     "demo:test": "mocha demo/tests/index.spec.js --compilers js:babel-register",
-    "demo:build": "webpack --config demo/webpack.config.js -p"
+    "demo:build": "rimraf demo/dist && webpack --config demo/webpack.config.js -p",
+    "demo:deploy": "gh-pages -d demo/dist"
   },
   "repository": {
     "type": "git",
@@ -61,6 +62,7 @@
     "copy-webpack-plugin": "^4.0.1",
     "cz-conventional-changelog": "1.1.6",
     "enzyme": "2.4.1",
+    "gh-pages": "^0.12.0",
     "ghooks": "1.3.2",
     "jsdom": "9.4.1",
     "json-loader": "0.5.4",


### PR DESCRIPTION
Use gh-pages library to publish contents of demo/dist to remote gh-pages branch. Requires running demo:build first.