### PR TITLE
feat(props) Add autoFocus props

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ export default SimpleForm
 * hideLabel
 * onSelect
 * options
+* autoFocus
 
 #### value
 Type: `String`,
@@ -266,6 +267,11 @@ const options = {
   options={options}
 />
 ```
+
+#### autoFocus
+Type: `Boolean`
+Required:  `false`
+Default: `false` 
 
 ### `geocodeByAddress` API
 

--- a/demo/Demo.js
+++ b/demo/Demo.js
@@ -90,6 +90,7 @@ class Demo extends React.Component {
             onSelect={this.handleSelect}
             classNames={cssClasses}
             autocompleteItem={AutocompleteItem}
+            autoFocus={true}
           />
           {this.state.loading ? <div className="loader">Loading...</div> : null}
           {!this.state.loading && this.state.geocodeResults ?

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -203,16 +203,17 @@ class PlacesAutocomplete extends React.Component {
   }
 
   renderCustomInput() {
-    const { children, value } = this.props
+    const { children, autoFocus, value } = this.props
     return React.cloneElement(children, {
       onChange: this.handleInputChange,
       onKeyDown: this.handleInputKeyDown,
+      autoFocus: autoFocus,
       value
     })
   }
 
   renderDefaultInput() {
-    const { classNames, placeholder, styles, value } = this.props
+    const { classNames, placeholder, styles, value, autoFocus } = this.props
     return (
       <input
         type="text"
@@ -222,6 +223,7 @@ class PlacesAutocomplete extends React.Component {
         onChange={this.handleInputChange}
         onKeyDown={this.handleInputKeyDown}
         style={styles.input}
+        autoFocus={autoFocus}
       />
     )
   }
@@ -250,6 +252,7 @@ PlacesAutocomplete.propTypes = {
   onSelect: React.PropTypes.func,
   placeholder: React.PropTypes.string,
   hideLabel: React.PropTypes.bool,
+  autoFocus: React.PropTypes.bool,
   autocompleteItem: React.PropTypes.func,
   classNames: React.PropTypes.shape({
     root: React.PropTypes.string,
@@ -284,6 +287,7 @@ PlacesAutocomplete.propTypes = {
 PlacesAutocomplete.defaultProps = {
   placeholder: 'Address',
   hideLabel: false,
+  autoFocus: false,
   classNames: {},
   autocompleteItem: ({ suggestion }) => (<div>{suggestion}</div>),
   styles: {},

--- a/src/tests/index.spec.js
+++ b/src/tests/index.spec.js
@@ -226,6 +226,18 @@ describe('custom input component', () => {
   })
 })
 
+describe('autoFocus prop', () => {
+  it('automatically gives focus when set to true', () => {
+    const wrapper = mount(<PlacesAutocomplete value="New York, NY" onChange={() => {}} autoFocus={true} />)
+    expect(wrapper.find('input').node).to.equal(document.activeElement)
+  })
+
+  it('does not give the input element a focus by default', () => {
+    const wrapper = mount(<PlacesAutocomplete value="New York, NY" onChange={() => {}} />)
+    expect(wrapper.find('input').node).to.not.equal(document.activeElement)
+  })
+})
+
 // TODO: test geocodeByAddress function
 describe('geocodeByAddress', () => {
   it('should be true', () => {


### PR DESCRIPTION
Resolves #11 .

Passing `autoFocus={true}` props will give the input element a focus. By
default, it does not give the element a focus.