### PR TITLE
feat(props): Remove children prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ export default SimpleForm
 #### Optional Props:
 
 * autocompleteItem
-* children
 * classNames
 * styles
 * placeholder
@@ -161,31 +160,6 @@ render() {
       onChange={this.onChange}
       autocompleteItem={AutocompleteItem}
     />
-  )
-}
-```
-
-#### children
-Type: `Element`
-Required: `false`
-
-You can add autocomplete functionality to an existing input element by wrapping it in `<PlacesAutocomplete>`.
-The wrapper will pass `onChange`, `onKeyDown`, and `value` props down to the child component.
-
-```js
-// custom input element example
-import MyCustomInput from 'my-custom-input'
-
-...
-
-render() {
-  return (
-    <PlacesAutocomplete
-      value={this.state.value}
-      onChange={this.onChange}
-    >
-      <MyCustomInput/>
-    </PlacesAutocomplete>
   )
 }
 ```

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -185,17 +185,7 @@ class PlacesAutocomplete extends React.Component {
     )
   }
 
-  renderCustomInput() {
-    const { children, autoFocus, value } = this.props
-    return React.cloneElement(children, {
-      onChange: this.handleInputChange,
-      onKeyDown: this.handleInputKeyDown,
-      autoFocus: autoFocus,
-      value
-    })
-  }
-
-  renderDefaultInput() {
+  renderInput() {
     const { classNames, placeholder, styles, value, autoFocus } = this.props
     return (
       <input
@@ -211,16 +201,14 @@ class PlacesAutocomplete extends React.Component {
     )
   }
 
-  // TODO: remove `classNames.container` in the next version release.
   render() {
-    const { classNames, children, styles } = this.props
+    const { classNames, styles } = this.props
     return (
       <div
         style={{ ...defaultStyles.root, ...styles.root }}
-        className={classNames.root || classNames.container || ''}
-      >
+        className={classNames.root || ''}>
         {this.renderLabel()}
-        {children ? this.renderCustomInput() : this.renderDefaultInput()}
+        {this.renderInput()}
         {this.renderOverlay()}
         {this.renderAutocomplete()}
       </div>
@@ -229,7 +217,6 @@ class PlacesAutocomplete extends React.Component {
 }
 
 PlacesAutocomplete.propTypes = {
-  children: React.PropTypes.element,
   value: React.PropTypes.string.isRequired,
   onChange: React.PropTypes.func.isRequired,
   onError: React.PropTypes.func,

--- a/src/tests/index.spec.js
+++ b/src/tests/index.spec.js
@@ -233,39 +233,6 @@ describe('AutocompletionRequest options', () => {
   })
 })
 
-describe('custom input component', () => {
-  it('renders a custom input component passed as a child', () => {
-    const wrapper = shallow(<PlacesAutocomplete value="LA" onChange={() => {}}><input className="test-input" type="text" onChange={() => {}}/></PlacesAutocomplete>)
-    expect(wrapper.find('.test-input')).to.have.length(1)
-  })
-
-  it('adds the correct props to the child component', () => {
-    const wrapper = shallow(<PlacesAutocomplete value="LA" onChange={() => {}}><input className="test-input" type="text"/></PlacesAutocomplete>)
-    expect(wrapper.find('.test-input').props().onChange).to.be.defined
-    expect(wrapper.find('.test-input').props().onKeyDown).to.be.defined
-    expect(wrapper.find('.test-input').props().value).to.be.defined
-  })
-
-  it('correctly sets the value prop of the custom input component', () => {
-    const wrapper = shallow(<PlacesAutocomplete value="LA" onChange={() => {}}><input className="test-input" type="text" onChange={() => {}}/></PlacesAutocomplete>)
-    expect(wrapper.find('.test-input').props().value).to.equal('LA')
-  })
-
-  it('executes the onChange callback when the custom input is changed', () => {
-    const spy = sinon.spy()
-    const wrapper = shallow(<PlacesAutocomplete value="LA" onChange={spy}><input className="test-input" type="text"/></PlacesAutocomplete>)
-    wrapper.find('.test-input').simulate('change', { target: { value: null } })
-    expect(spy.calledOnce).to.equal(true)
-  })
-
-  it('executes handleInputKeyDown when a keyDown event happens on the custom input', () => {
-    const spy = sinon.spy(PlacesAutocomplete.prototype, 'handleInputKeyDown')
-    const wrapper = shallow(<PlacesAutocomplete value="LA" onChange={() => {}}><input className="test-input" type="text"/></PlacesAutocomplete>)
-    wrapper.find('.test-input').simulate('keyDown', { keyCode: null })
-    expect(spy.calledOnce).to.equal(true)
-  })
-})
-
 describe('autoFocus prop', () => {
   it('automatically gives focus when set to true', () => {
     const wrapper = mount(<PlacesAutocomplete value="New York, NY" onChange={() => {}} autoFocus={true} />)


### PR DESCRIPTION
Removed a feature which allowed user to pass custom input element as children prop to simplify the
library.

BREAKING CHANGE: Removed children prop