### PR TITLE
Fix address selection on click

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -187,7 +187,7 @@ class PlacesAutocomplete extends React.Component {
           <div
             key={p.placeId}
             onMouseOver={() => this._setActiveItemAtIndex(p.index)}
-            onClick={() => this.selectAddress(p.suggestion, p.placeId)}
+            onMouseDown={() => this.selectAddress(p.suggestion, p.placeId)}
             style={{ ...defaultStyles.autocompleteItem, ...styles.autocompleteItem, ...this.autocompleteItemStyle(p.active) }}>
             {this.props.autocompleteItem({ suggestion: p.suggestion, formattedSuggestion: p.formattedSuggestion })}
           </div>


### PR DESCRIPTION
This commit https://github.com/kenny-hibino/react-places-autocomplete/commit/3f3f47164a6e8679faa463a80989c8c3b87de068 breaks the address selection `onClick` event because this event is triggered after the `onBlur` event.

I used the `onMouseDown` event as it's triggered before the `onBlur` within the event loop.