### PR TITLE
Allow classNames to override default styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ You can enable/disable Airbnb style soft autocomplete in the input field. (NOTE:
 Type: `Object`,
 Required: `false`
 
-You can give a custom css classes to elements.
-Accepted keys are `root`, `input`, `autocompleteContainer`
+You can give a custom css classes to elements. Setting a custom className will override
+the `defaultStyles` for that element.
+Accepted keys are `root`, `input`, `autocompleteContainer`, `autocompleteItem`, `autocompleteItemActive`
 
 ```js
 // classNames example

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -34,6 +34,8 @@ PlacesAutocomplete.propTypes = {
     root: React.PropTypes.string,
     input: React.PropTypes.string,
     autocompleteContainer: React.PropTypes.string,
+    autocompleteItem: React.PropTypes.string,
+    autocompleteItemActive: React.PropTypes.string
   }),
   styles: React.PropTypes.shape({
     root: React.PropTypes.object,

--- a/src/PlacesAutocompleteBasic.js
+++ b/src/PlacesAutocompleteBasic.js
@@ -160,7 +160,7 @@ class PlacesAutocompleteBasic extends Component {
   autocompleteItemStyle(active) {
     if (active) {
       return {
-        ...(!classNames.autocompleteContainer ? defaultStyles.autocompleteItemActive : {}),
+        ...(!this.props.classNames.autocompleteContainer ? defaultStyles.autocompleteItemActive : {}),
         ...this.props.styles.autocompleteItemActive
       }
     } else {

--- a/src/PlacesAutocompleteBasic.js
+++ b/src/PlacesAutocompleteBasic.js
@@ -165,21 +165,31 @@ class PlacesAutocompleteBasic extends Component {
     }
   }
 
+  autocompleteItemClassNames(active) {
+    const { classNames } = this.props
+    if (active) {
+      return (classNames.autocompleteItem || '') + ' ' + (classNames.autocompleteItemActive || '')
+    } else {
+      return classNames.autocompleteItem || ''
+    }
+  }
+
   renderAutocomplete() {
     const { autocompleteItems } = this.state
-    const { styles } = this.props
+    const { classNames, styles } = this.props
     if (autocompleteItems.length === 0) { return null }
     return (
       <div
         id="PlacesAutocomplete__autocomplete-container"
-        className={this.props.classNames.autocompleteContainer || ''}
-        style={{ ...defaultStyles.autocompleteContainer, ...styles.autocompleteContainer }}>
+        className={classNames.autocompleteContainer || ''}
+        style={!classNames.autocompleteContainer ? { ...defaultStyles.autocompleteContainer, ...styles.autocompleteContainer } : {}}>
         {autocompleteItems.map((p, idx) => (
           <div
             key={p.placeId}
             onMouseOver={() => this.setActiveItemAtIndex(p.index)}
             onMouseDown={() => this.selectAddress(p.suggestion, p.placeId)}
-            style={{ ...defaultStyles.autocompleteItem, ...styles.autocompleteItem, ...this.autocompleteItemStyle(p.active) }}>
+            className={this.autocompleteItemClassNames(p.active)}
+            style={!classNames.autocompleteItem ? { ...defaultStyles.autocompleteItem, ...styles.autocompleteItem, ...this.autocompleteItemStyle(p.active) } : {}}>
             {this.props.autocompleteItem({ suggestion: p.suggestion, formattedSuggestion: p.formattedSuggestion })}
           </div>
         ))}
@@ -198,7 +208,7 @@ class PlacesAutocompleteBasic extends Component {
         onChange={this.handleInputChange}
         onKeyDown={this.handleInputKeyDown}
         onBlur={() => this.clearAutocomplete()}
-        style={styles.input}
+        style={!classNames.input ? styles.input : {}}
         autoFocus={autoFocus}
         name={inputName || ''}
       />
@@ -209,7 +219,7 @@ class PlacesAutocompleteBasic extends Component {
     const { classNames, styles } = this.props
     return (
       <div
-        style={{ ...defaultStyles.root, ...styles.root }}
+        style={!classNames.root ? { ...defaultStyles.root, ...styles.root } : {}}
         className={classNames.root || ''}>
         {this.renderInput()}
         {this.renderAutocomplete()}

--- a/src/PlacesAutocompleteBasic.js
+++ b/src/PlacesAutocompleteBasic.js
@@ -159,7 +159,10 @@ class PlacesAutocompleteBasic extends Component {
 
   autocompleteItemStyle(active) {
     if (active) {
-      return { ...defaultStyles.autocompleteItemActive, ...this.props.styles.autocompleteItemActive }
+      return {
+        ...(!classNames.autocompleteContainer ? defaultStyles.autocompleteItemActive : {}),
+        ...this.props.styles.autocompleteItemActive
+      }
     } else {
       return {}
     }
@@ -182,14 +185,14 @@ class PlacesAutocompleteBasic extends Component {
       <div
         id="PlacesAutocomplete__autocomplete-container"
         className={classNames.autocompleteContainer || ''}
-        style={!classNames.autocompleteContainer ? { ...defaultStyles.autocompleteContainer, ...styles.autocompleteContainer } : {}}>
+        style={{ ...(!classNames.autocompleteContainer ? defaultStyles.autocompleteContainer : {}), ...styles.autocompleteContainer }}>
         {autocompleteItems.map((p, idx) => (
           <div
             key={p.placeId}
             onMouseOver={() => this.setActiveItemAtIndex(p.index)}
             onMouseDown={() => this.selectAddress(p.suggestion, p.placeId)}
             className={this.autocompleteItemClassNames(p.active)}
-            style={!classNames.autocompleteItem ? { ...defaultStyles.autocompleteItem, ...styles.autocompleteItem, ...this.autocompleteItemStyle(p.active) } : {}}>
+            style={{ ...(!classNames.autocompleteItem ? defaultStyles.autocompleteItem : {}), ...styles.autocompleteItem, ...this.autocompleteItemStyle(p.active) }}>
             {this.props.autocompleteItem({ suggestion: p.suggestion, formattedSuggestion: p.formattedSuggestion })}
           </div>
         ))}
@@ -208,7 +211,7 @@ class PlacesAutocompleteBasic extends Component {
         onChange={this.handleInputChange}
         onKeyDown={this.handleInputKeyDown}
         onBlur={() => this.clearAutocomplete()}
-        style={!classNames.input ? styles.input : {}}
+        style={styles.input}
         autoFocus={autoFocus}
         name={inputName || ''}
       />
@@ -219,7 +222,7 @@ class PlacesAutocompleteBasic extends Component {
     const { classNames, styles } = this.props
     return (
       <div
-        style={!classNames.root ? { ...defaultStyles.root, ...styles.root } : {}}
+        style={{ ...(!classNames.root ? defaultStyles.root : {}), ...styles.root }}
         className={classNames.root || ''}>
         {this.renderInput()}
         {this.renderAutocomplete()}

--- a/src/PlacesAutocompleteWithTypeAhead.js
+++ b/src/PlacesAutocompleteWithTypeAhead.js
@@ -327,7 +327,10 @@ class PlacesAutocompleteWithTypeAhead extends Component {
 
   autocompleteItemStyle(active) {
     if (active) {
-      return { ...defaultStyles.autocompleteItemActive, ...this.props.styles.autocompleteItemActive }
+      return {
+        ...(!this.props.classNames.autocompleteItem ? defaultStyles.autocompleteItemActive : {}),
+        ...this.props.styles.autocompleteItemActive
+      }
     } else {
       return {}
     }
@@ -350,14 +353,14 @@ class PlacesAutocompleteWithTypeAhead extends Component {
       <div
         id="PlacesAutocomplete__autocomplete-container"
         className={classNames.autocompleteContainer || ''}
-        style={!classNames.autocompleteContainer ? { ...defaultStyles.autocompleteContainer, ...styles.autocompleteContainer } : {}}>
+        style={{ ...(!classNames.autocompleteContainer ? defaultStyles.autocompleteContainer : {}), ...styles.autocompleteContainer }}>
         {autocompleteItems.map((p, idx) => (
           <div
             key={p.placeId}
             onMouseOver={() => this.setActiveItemAtIndex(p.index)}
             onMouseDown={() => this.handleAutocompleteItemMouseDown(p.suggestion, p.placeId)}
             className={this.autocompleteItemClassNames(p.active)}
-            style={!classNames.autocompleteItem ? { ...defaultStyles.autocompleteItem, ...styles.autocompleteItem, ...this.autocompleteItemStyle(p.active) } : {}}>
+            style={{ ...(!classNames.autocompleteItem ? defaultStyles.autocompleteItem : {}), ...styles.autocompleteItem, ...this.autocompleteItemStyle(p.active) }}>
             {this.props.autocompleteItem({ suggestion: p.suggestion, formattedSuggestion: p.formattedSuggestion })}
           </div>
         ))}
@@ -383,7 +386,7 @@ class PlacesAutocompleteWithTypeAhead extends Component {
         onChange={this.handleInputChange}
         onKeyDown={this.handleInputKeyDown}
         onBlur={() => this.clearAutocomplete()}
-        style={!classNames.input ? styles.input : {}}
+        style={styles.input}
         autoFocus={autoFocus}
         name={inputName || ''}
         ref="inputField"
@@ -395,7 +398,7 @@ class PlacesAutocompleteWithTypeAhead extends Component {
     const { classNames, styles } = this.props
     return (
       <div
-        style={!classNames.root ? { ...defaultStyles.root, ...styles.root } : {}}
+        style={{ ...(!classNames.root ? defaultStyles.root : {}), ...styles.root }}
         className={classNames.root || ''}>
         {this.renderInput()}
         {this.renderAutocomplete()}

--- a/src/PlacesAutocompleteWithTypeAhead.js
+++ b/src/PlacesAutocompleteWithTypeAhead.js
@@ -333,21 +333,31 @@ class PlacesAutocompleteWithTypeAhead extends Component {
     }
   }
 
+  autocompleteItemClassNames(active) {
+    const { classNames } = this.props
+    if (active) {
+      return (classNames.autocompleteItem || '') + ' ' + (classNames.autocompleteItemActive || '')
+    } else {
+      return classNames.autocompleteItem || ''
+    }
+  }
+
   renderAutocomplete() {
     const { autocompleteItems } = this.state
-    const { styles } = this.props
+    const { classNames, styles } = this.props
     if (autocompleteItems.length === 0) { return null }
     return (
       <div
         id="PlacesAutocomplete__autocomplete-container"
-        className={this.props.classNames.autocompleteContainer || ''}
-        style={{ ...defaultStyles.autocompleteContainer, ...styles.autocompleteContainer }}>
+        className={classNames.autocompleteContainer || ''}
+        style={!classNames.autocompleteContainer ? { ...defaultStyles.autocompleteContainer, ...styles.autocompleteContainer } : {}}>
         {autocompleteItems.map((p, idx) => (
           <div
             key={p.placeId}
             onMouseOver={() => this.setActiveItemAtIndex(p.index)}
             onMouseDown={() => this.handleAutocompleteItemMouseDown(p.suggestion, p.placeId)}
-            style={{ ...defaultStyles.autocompleteItem, ...styles.autocompleteItem, ...this.autocompleteItemStyle(p.active) }}>
+            className={this.autocompleteItemClassNames(p.active)}
+            style={!classNames.autocompleteItem ? { ...defaultStyles.autocompleteItem, ...styles.autocompleteItem, ...this.autocompleteItemStyle(p.active) } : {}}>
             {this.props.autocompleteItem({ suggestion: p.suggestion, formattedSuggestion: p.formattedSuggestion })}
           </div>
         ))}
@@ -373,7 +383,7 @@ class PlacesAutocompleteWithTypeAhead extends Component {
         onChange={this.handleInputChange}
         onKeyDown={this.handleInputKeyDown}
         onBlur={() => this.clearAutocomplete()}
-        style={styles.input}
+        style={!classNames.input ? styles.input : {}}
         autoFocus={autoFocus}
         name={inputName || ''}
         ref="inputField"
@@ -385,7 +395,7 @@ class PlacesAutocompleteWithTypeAhead extends Component {
     const { classNames, styles } = this.props
     return (
       <div
-        style={{ ...defaultStyles.root, ...styles.root }}
+        style={!classNames.root ? { ...defaultStyles.root, ...styles.root } : {}}
         className={classNames.root || ''}>
         {this.renderInput()}
         {this.renderAutocomplete()}


### PR DESCRIPTION
hi @kenny-hibino!

this allows users to override the default inline styling in `defaultStyles.js` by setting the respective element's `classNames`. the way I ended up implementing it, it's still possible to use both `classNames` and `styles` props, but let me know if you'd rather stick with having to choose one or the other (I think [react-modal](https://github.com/reactjs/react-modal) does it this way). 

resolves https://github.com/kenny-hibino/react-places-autocomplete/issues/30

