### PR TITLE
add prop-types future proof for React v16 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     ]
   },
   "dependencies": {
-    "react": "^15.0.0"
+    "prop-types": "^15.5.8",
+    "react": "^15.3.0"
   }
 }

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -4,7 +4,8 @@
 * See https://kenny-hibino.github.io/react-places-autocomplete
 */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import defaultStyles from './defaultStyles'
 
 class PlacesAutocomplete extends Component {


### PR DESCRIPTION
Added the [prop-types](https://www.npmjs.com/package/prop-types) package to avoid issues with deprecation of `React.PropTypes` in React v16. This was completed per the [suggestion](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) found in the React blog. Unfortunately this has not removed the following deprecation warning from showing during development. 
```
Warning: Accessing PropTypes via the main React package is deprecated.
Use the prop-types package from npm instead.
```
This likely means that one of the dependencies is using `React.PropTypes`. It may help to update those as time passes (before the next React release).

This is my first pull request on for this package and I was not sure of the build process... so I only added `prop-types` to the dependencies and imported the packaged in the `PlacesAutocomplete` component. If you need additional changes please let me know.