### PR TITLE
Treat Tab key same as Enter for select purposes

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -151,6 +151,9 @@ class PlacesAutocomplete extends Component {
       case 'Escape':
         this.clearAutocomplete()
         break
+      case 'Tab':
+        this.handleEnterKey()
+        break
     }
 
     if (this.props.inputProps.onKeyDown) {


### PR DESCRIPTION
First off - thank you so much for this project, it works like a charm and saved me a bunch of time.

I have one suggestion: I'm using this auto-complete as part of a larger form, and my users are used to tabbing from field to field, however this does not trigger the onSelect handler. Do you see any issues triggering the same behavior that the Enter key triggers from the Tab key as well (without suppressing default, so that the form field is indeed advanced)?

Thank you for consideration.