### PR TITLE
Add debounce support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ export default SimpleForm
 * [`onSelect`](#onSelect)
 * [`onEnterKeyDown`](#onEnterKeyDown)
 * [`options`](#options)
+* [`debounce`](#debounce)
 
 <a name="inputProps"></a>
 #### inputProps
@@ -362,6 +363,14 @@ const options = {
   options={options}
 />
 ```
+
+<a name="debounce"></a>
+#### debounce
+Type: `Number`
+Required: `false`
+Default: `200`
+
+The number of milliseconds to delay before making a call to Google API.
 
 <a name="utility-functions"></a>
 ## Utility Functions

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     ]
   },
   "dependencies": {
+    "lodash.debounce": "^4.0.8",
     "prop-types": "^15.5.8",
     "react": "^15.3.0"
   }

--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -6,6 +6,7 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import debounce from 'lodash.debounce'
 import defaultStyles from './defaultStyles'
 
 class PlacesAutocomplete extends Component {
@@ -17,6 +18,7 @@ class PlacesAutocomplete extends Component {
     this.autocompleteCallback = this.autocompleteCallback.bind(this)
     this.handleInputKeyDown = this.handleInputKeyDown.bind(this)
     this.handleInputChange = this.handleInputChange.bind(this)
+    this.debouncedFetchPredictions = debounce(this.fetchPredictions, this.props.debounce)
   }
 
   componentDidMount() {
@@ -54,6 +56,11 @@ class PlacesAutocomplete extends Component {
         formattedSuggestion: formattedSuggestion(p.structured_formatting),
       }))
     })
+  }
+
+  fetchPredictions() {
+    const { value } = this.props.inputProps;
+    this.autocompleteService.getPlacePredictions({ ...this.props.options, input: value || '' }, this.autocompleteCallback)
   }
 
   clearAutocomplete() {
@@ -176,7 +183,7 @@ class PlacesAutocomplete extends Component {
       this.clearAutocomplete()
       return
     }
-    this.autocompleteService.getPlacePredictions({ ...this.props.options, input: event.target.value }, this.autocompleteCallback)
+    this.debouncedFetchPredictions()
   }
 
   handleInputOnBlur(event) {
@@ -311,6 +318,7 @@ PlacesAutocomplete.propTypes = {
     ]),
     types: PropTypes.array
   }),
+  debounce: PropTypes.number,
 }
 
 PlacesAutocomplete.defaultProps = {
@@ -320,6 +328,7 @@ PlacesAutocomplete.defaultProps = {
   autocompleteItem: ({ suggestion }) => (<div>{suggestion}</div>),
   styles: {},
   options: {},
+  debounce: 200,
 }
 
 export default PlacesAutocomplete

--- a/src/tests/index.spec.js
+++ b/src/tests/index.spec.js
@@ -208,13 +208,16 @@ describe('custom inline styles', () => {
      ...testInputProps,
      value: 'Boston, MA',
    }
-   it('calls getPlacePredictions with the correct options', () => {
+   it('calls getPlacePredictions with the correct options', (done) => {
      global.google.maps.places.AutocompleteService.prototype.getPlacePredictions = (request, callback) => {}
      const spy = sinon.spy(global.google.maps.places.AutocompleteService.prototype, 'getPlacePredictions')
      const options = { radius: 2000, types: ['address'] }
      const wrapper = mount(<PlacesAutocomplete inputProps={inputProps} options={options} />)
      wrapper.find('input').simulate('change', { target: { value: 'Los Angeles, CA' } })
-     expect(spy.calledWith({ ...options, input: 'Los Angeles, CA' })).to.be.true
+     setTimeout(() => {
+       done()
+       expect(spy.calledWith({ ...options, input: 'Los Angeles, CA' })).to.be.true
+     }, 0)
    })
  })
 


### PR DESCRIPTION
Debounce calls to Google Maps API.
 Allow user to set the number of millisconde through `debounce`prop.

Closes #79