### PR TITLE
fix($browser): Added e.preventDefault() to AutoCompleteItem touch event

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -74,7 +74,10 @@ class PlacesAutocomplete extends Component {
     this.setState({ autocompleteItems: [] })
   }
 
-  selectAddress(address, placeId) {
+  selectAddress(address, placeId, e) {
+    if (e !== undefined) {
+      e.preventDefault();
+    }
     this.clearAutocomplete()
     this.handleSelect(address, placeId)
   }
@@ -265,9 +268,9 @@ class PlacesAutocomplete extends Component {
               <div
                 key={p.placeId}
                 onMouseOver={() => this.setActiveItemAtIndex(p.index)}
-                onMouseDown={() => this.selectAddress(p.suggestion, p.placeId)}
+                onMouseDown={(e) => this.selectAddress(p.suggestion, p.placeId, e)}
                 onTouchStart={() => this.setActiveItemAtIndex(p.index)}
-                onTouchEnd={() => this.selectAddress(p.suggestion, p.placeId)}
+                onTouchEnd={(e) => this.selectAddress(p.suggestion, p.placeId, e)}
                 style={ p.active ? this.inlineStyleFor('autocompleteItem', 'autocompleteItemActive') :this.inlineStyleFor('autocompleteItem') }
                 className={ p.active ? this.classNameFor('autocompleteItem', 'autocompleteItemActive') : this.classNameFor('autocompleteItem') }>
                 {this.props.autocompleteItem({ suggestion: p.suggestion, formattedSuggestion: p.formattedSuggestion })}


### PR DESCRIPTION
Fixed a bug where touching a suggested address would trigger any clickable elements beneath it

Closed issue #123