### PR TITLE
Add ID attr to input for label accessibility

### DIFF
--- a/src/PlacesAutocomplete.js
+++ b/src/PlacesAutocomplete.js
@@ -254,7 +254,7 @@ class PlacesAutocomplete extends Component {
         id="PlacesAutocomplete__root"
         style={this.inlineStyleFor('root')}
         className={this.classNameFor('root')}>
-        <input {...inputProps} />
+        <input id="PlacesAutocomplete__input" {...inputProps} />
         {autocompleteItems.length > 0 && (
           <div
             id="PlacesAutocomplete__autocomplete-container"


### PR DESCRIPTION
Accessibility guidelines recommend pairing labels with inputs in forms.

> ```
> <label for="name">Name:</label>
> <input id="name" type="text" name="textfield">
> ```
> Matching for and id values associate the label with the appropriate form control. Because id must be unique on each page, only one label can be associated to each unique form element. This means you cannot have one label for multiple form elements. Additionally, screen readers do not support multiple labels that are associated to the same form element.

https://webaim.org/techniques/forms/controls

> 
> Note
> Another benefit of using labels is that the user can click on the label itself to set focus to the form element. This is useful to some with motor disabilities, particularly when selecting small checkboxes and radio buttons. You can try this by clicking on the word "Name:" above to see focus set to the text box. Clicking adjacent labels provides an easy way to check for proper form labeling.

I did read in the Gitter channel that the label element was removed from the plugin. However, a defauly `id` parameter was included on the input field, for example `PlacesAutocomplete__input`, users could add a label element outside of the rendered markup and meet accessibility standards. 

I'm currently resolving this issue after rendering the component, but it seems easy enough to make `id` an optional parameter 

```
  componentDidMount() {
    // runs after component is rendered
    // adds id attr to input box so that the label el can connect
    let parent = document.getElementById('PlacesAutocomplete__root');
    let input = parent.children[0];
    input.id = "PlacesAutocomplete__input";
  }
```
Label markup
```
<label for="PlacesAutocomplete__input"></label>
```